### PR TITLE
Implementation of product delete by admin

### DIFF
--- a/components/products/controller.js
+++ b/components/products/controller.js
@@ -36,6 +36,41 @@ class ProductController {
       next(e);
     }
   }
+
+  /**
+ * @description - Function to delete a lready existing products
+ *
+ * @param {object} req - HTTP request object.
+ *
+ * @param {object} res - HTTP response object.
+ *
+ * @param {object} next - Function to pass control to next function.
+ *
+ * @return {void} - No return value
+ */
+  async deleteProduct(req, res, next) {
+    const {
+      body: { user: { isadmin } },
+      params: { product_id }
+    } = req;
+
+    if (!isadmin) {
+      return sendErrorMessage(res, 401, 'User Unauthorized');
+    }
+
+    const product = await repository.getOne({ uuid: product_id });
+
+    if (!product) {
+      return sendErrorMessage(res, 404, "Product doesn't exist");
+    }
+
+    try {
+      await repository.delete(product_id);
+      sendSuccessMessage(res, 200, 'Deleted product successfully');
+    } catch (e) {
+      next(e);
+    }
+  }
 }
 
 export default new ProductController();

--- a/components/products/repository.js
+++ b/components/products/repository.js
@@ -55,6 +55,18 @@ class ProductRepository {
   }
 
   /**
+   * @description - Function to delete product.
+   *
+   * @param {string} uuid - Product's uuid
+   *
+   * @returns {object} - Returns a promise for product creation.
+   */
+  async delete(uuid) {
+    const product = await this.getOne({ uuid });
+    return product.destroy();
+  }
+
+  /**
    * @description - Function get one Products.
    *
    * @param {object} condition - Condition to search for.
@@ -64,7 +76,7 @@ class ProductRepository {
    * @returns {object} Returns a promise for product matched.
    */
   async getOne(condition = {}, include = '') {
-    return this.rep.findOne(
+    return this.model.findOne(
       { where: condition, include }
     );
   }

--- a/components/products/routes.js
+++ b/components/products/routes.js
@@ -3,7 +3,7 @@
  */
 
 import controller from './controller';
-import productValidations from './validation';
+import { productValidations, productDeleteValidations } from './validation';
 import { passToken } from '../../utils';
 
 export default [
@@ -11,5 +11,10 @@ export default [
     path: '/product',
     method: 'post',
     handlers: [...productValidations, passToken, controller.createProduct]
+  },
+  {
+    path: '/product/:product_id',
+    method: 'delete',
+    handlers: [...productDeleteValidations, passToken, controller.deleteProduct]
   }
 ];

--- a/components/products/validation.js
+++ b/components/products/validation.js
@@ -5,7 +5,7 @@
 import { check } from 'express-validator';
 import { generateErrorReport } from '../../utils';
 
-export default [
+export const productValidations = [
   check('name', 'Name must be present')
     .isString()
     .trim()
@@ -48,6 +48,20 @@ export default [
     .escape()
     .trim()
     .isBoolean(),
+
+  generateErrorReport
+];
+
+export const productDeleteValidations = [
+  check('product_id', 'Must not be empty')
+    .trim()
+    .escape()
+    .not()
+    .isEmpty(),
+  check('product_id', 'Invalid product uuid')
+    .trim()
+    .escape()
+    .isUUID(),
 
   generateErrorReport
 ];

--- a/database/seeders/20200218102756-products.js
+++ b/database/seeders/20200218102756-products.js
@@ -187,7 +187,8 @@ module.exports = {
       createdAt: Sequelize.literal('NOW()'),
       updatedAt: Sequelize.literal('NOW()')
     }
-  ], {})},
+  ], {})
+},
 
   down: queryInterface => queryInterface.bulkDelete('Products', null, {})
 };

--- a/docs/product/delete.yaml
+++ b/docs/product/delete.yaml
@@ -1,0 +1,60 @@
+paths:
+  /api/v1/product/{product_uuid}:
+    security:
+      - bearerAuth: []
+    delete:
+      summary: Admin product deletion endpoint
+      tags:
+        - Product
+      operationId: deleteProduct
+      produces:
+        - application/json
+      parameters:
+        - name: "Authorization"
+          in: "header"
+          required: false
+          default: "Bearer {token}"
+          type: "string"
+
+        - name: product_uuid
+          in: path
+          type: string
+          required: true
+          summary: "Products's name"
+
+      responses:
+        200:
+          description: Successful product creation
+          content:
+            application/json
+          schema:
+            example:
+              status: "sucess"
+              data: "Deleted product successfully"
+        401:
+          description: Unauthorized Access
+          content:
+            application/json
+          schema:
+            example:
+              status: "error"
+              error: "Authorization Failed, please login is required"
+
+        404:
+          description: Uknown product
+          content:
+            application/json
+          schema:
+            example:
+              status: "error"
+              error: "Product doesn't exist"
+
+        406:
+          description: Unacceptable inputs
+          content:
+            application/json
+          schema:
+            example:
+              status: "error"
+              error:
+                - product_id: "Invalid product uuid"


### PR DESCRIPTION
  **What does this PR do?**

  Implementation of an endpoint to enable admins to delete a product, using the Moch-Shop platform, provided admin are signed into their accounts.

  **Description of Task to be completed?**

  * Completed the implementation of endpoint `DELETE: /api/v1/product/:product_id` for admins.

  *  Completed documentation of endpoint using swagger

  **How should this be manually tested?**

  * clone repository `git clone github.com:Wokoro/mock-shop.git`

  * Install npm packages `npm install`

  * Start server`npm run start`

  * Using postman provide signin details in `POST: localhost:3000/api/v1/product/:product_id` 
endpoint

  **Any background context you want to provide?**

  none

  **What are the relevant stories?**

  none

  **Screenshots (if appropriate)**

**Successful product deletion**

![valid_detials](https://user-images.githubusercontent.com/23240530/75021338-1501b280-5449-11ea-9317-e92e81172629.jpg)

**Invalid Product UUID**

![invalid_uuid](https://user-images.githubusercontent.com/23240530/75021520-66aa3d00-5449-11ea-9af9-831d4efbe288.jpg)

**Nonexisting product**

![invalid_detials](https://user-images.githubusercontent.com/23240530/75021872-fc45cc80-5449-11ea-84c9-15e12a8cb5d2.jpg)

**Unauthorized User**

![invalid_detials](https://user-images.githubusercontent.com/23240530/75021678-a4a76100-5449-11ea-80f2-c037ae53f9d2.jpg)

  **Questions:**

 none
