### PR TITLE
Implementation for viewing all products by admins and users

### DIFF
--- a/components/products/controller.js
+++ b/components/products/controller.js
@@ -107,6 +107,31 @@ class ProductController {
       next(e);
     }
   }
+
+  /**
+   * @description - Function to get all products
+   *
+   * @param {object} req - Request body property, with product details.
+   *
+   * @param {object} res - Express response object.
+   *
+   * @param {object} next - Function to pass control to next function.
+   *
+   * @return {void} - No return value
+   */
+  async getProducts(req, res, next) {
+    try {
+      const result = await repository.getAll();
+
+      if (result.length === 0) {
+        return sendSuccessMessage(res, 204, 'No products available');
+      }
+
+      sendSuccessMessage(res, 200, result);
+    } catch (e) {
+      next(e);
+    }
+  }
 }
 
 export default new ProductController();

--- a/components/products/repository.js
+++ b/components/products/repository.js
@@ -77,7 +77,7 @@ class ProductRepository {
     uuid,
     {
       name, description, category,
-      price, image_url, in_stock 
+      price, image_url, in_stock
     }
   ) {
     const product = await this.getOne({ uuid });
@@ -102,6 +102,21 @@ class ProductRepository {
    */
   async getOne(condition = {}, include = '') {
     return this.model.findOne(
+      { where: condition, include }
+    );
+  }
+
+  /**
+   * @description - Function get all Products.
+   *
+   * @param {object} condition - Condition to search for.
+   *
+   * @param {string} include - Optional associated field to include
+   *
+   * @returns {object} Returns a promise for product matched.
+   */
+  async getAll(condition = {}, include = '') {
+    return this.model.findAll(
       { where: condition, include }
     );
   }

--- a/components/products/routes.js
+++ b/components/products/routes.js
@@ -27,4 +27,9 @@ export default [
       controller.updateProduct
     ]
   },
+  {
+    path: '/products',
+    method: 'get',
+    handlers: [controller.getProducts]
+  },
 ];

--- a/database/seeders/20200218102756-products.js
+++ b/database/seeders/20200218102756-products.js
@@ -5,8 +5,7 @@ import uuid from 'uuid/v4';
 const admin_uuid = '138eab76-bf3d-48be-9dc7-52136376f04d';
 
 module.exports = {
-  up: async (queryInterface, Sequelize) => {
-    return queryInterface.bulkInsert('Products', [
+  up: async (queryInterface, Sequelize) => queryInterface.bulkInsert('Products', [
     {
       uuid: uuid(),
       user_uuid: admin_uuid,
@@ -187,7 +186,7 @@ module.exports = {
       createdAt: Sequelize.literal('NOW()'),
       updatedAt: Sequelize.literal('NOW()')
     }
-  ], {})},
+  ], {}),
 
   down: queryInterface => queryInterface.bulkDelete('Products', null, {})
 };

--- a/docs/product/products.yaml
+++ b/docs/product/products.yaml
@@ -1,0 +1,106 @@
+paths:
+  /api/v1/products:
+    security:
+      - bearerAuth: []
+    get:
+      summary: Viewing all products endpoint
+      tags:
+        - Product
+      operationId: getProducts
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Successful return of products
+          content:
+            application/json
+          schema:
+            example:
+              status: "success"
+              data:
+                - uuid: "2b5199f6-c714-47c9-b9fd-2a94b66773eb"
+                  name: "iphone"
+                  user_uuid: "341007b4-e254-48a5-9cf6-f254bed78310"
+                  description: "A very powerful phone with high picture quality"
+                  category: "electronics"
+                  price: 20000
+                  imageUrl: "http://iphone_x.com/iphone.png"
+                  inStock: true
+                  createdAt: "2020-02-19T01:17:13.838Z"
+                  updatedAt: "2020-02-19T01:17:13.838Z"
+
+                - uuid: "7435abde-7ca0-47fd-b538-f4df145f32fe"
+                  name: "Mouse"
+                  user_uuid: "138eab76-bf3d-48be-9dc7-52136376f04d"
+                  description: "Bluethoot powered mouse"
+                  category: "electronics"
+                  price: 4880
+                  imageUrl: "http://softworld/mouse.png"
+                  inStock: true
+                  createdAt: "2020-02-18T14:38:46.306Z"
+                  updatedAt: "2020-02-18T14:38:46.306Z"
+
+                - uuid: "1d8d6cda-af05-4629-ab5f-e116667de7b7"
+                  name: "Desktop"
+                  user_uuid: "138eab76-bf3d-48be-9dc7-52136376f04d"
+                  description: "Complete Desktop"
+                  category: "electronics"
+                  price: 94000
+                  imageUrl: "http://softworld/desktop.png"
+                  inStock: true
+                  createdAt: "2020-02-18T14:38:46.306Z"
+                  updatedAt: "2020-02-18T14:38:46.306Z"
+
+                - uuid: "986643d1-02fd-426d-8d0f-81f2e336685e"
+                  name: "Samsung J5"
+                  user_uuid: "138eab76-bf3d-48be-9dc7-52136376f04d"
+                  description: "Samsung phone with high quality camera"
+                  category: "electronics"
+                  price: 50000
+                  imageUrl: "http://softworld/phone.png"
+                  inStock: true
+                  createdAt: "2020-02-18T14:38:46.306Z"
+                  updatedAt: "2020-02-18T14:38:46.306Z"
+
+                - uuid: "cf1a22ee-cebb-40e7-bafc-6d6f86943050"
+                  name: "Polo shirts"
+                  user_uuid: "138eab76-bf3d-48be-9dc7-52136376f04d"
+                  description: "Body fitted shirts"
+                  category: "clothes"
+                  price: 2000
+                  imageUrl: "http://softworld/shirts.png"
+                  inStock: true
+                  createdAt: "2020-02-18T14:38:46.306Z"
+                  updatedAt: "2020-02-18T14:38:46.306Z"
+
+                - uuid: "1d20495d-d056-40d2-bb75-32f1cae8c216"
+                  name: "Mega microphone"
+                  user_uuid: "138eab76-bf3d-48be-9dc7-52136376f04d"
+                  description: "257KHZ Microphone"
+                  category: "electronics"
+                  price: 20000
+                  imageUrl: "http://softworld/megaphone.png"
+                  inStock: true
+                  createdAt: "2020-02-18T14:38:46.306Z"
+                  updatedAt: "2020-02-18T14:38:46.306Z"
+
+                - uuid: "72fc2494-88a0-4f75-a341-f39a968477b9"
+                  name: "Canon Camera"
+                  user_uuid: "138eab76-bf3d-48be-9dc7-52136376f04d"
+                  description: "500px ultra high quality camera"
+                  category: "electronics"
+                  price: 20000
+                  imageUrl: "http://softworld/megacam.png"
+                  inStock: true
+                  createdAt: "2020-02-18T14:38:46.306Z"
+                  updatedAt: "2020-02-18T14:38:46.306Z"
+
+
+        204:
+          description: No content available
+          content:
+            application/json
+          schema:
+            example:
+              status: "success"
+              data: "No products available"


### PR DESCRIPTION
  **What does this PR do?**

  Implementation of an endpoint to enable admins and users to view all products on the platform.

  **Description of Task to be completed?**

 * Completed the implementation of endpoint `GET: /api/v1/products` for admins and users.

 * Completed documentation of endpoint using swagger

  **How should this be manually tested?**

  * clone repository `git clone github.com:Wokoro/mock-shop.git`

  * Install npm packages `npm install`

  * Start server`npm run start`

  * Using postman navigate to `GET: localhost:3000/api/v1/products` endpoint to view available products.

  **Any background context you want to provide?**

  none

  **What are the relevant stories?**

  none

  **Screenshots (if appropriate)**

**Successful products listing**

![invalid_detials](https://user-images.githubusercontent.com/23240530/75029495-fefaee80-5456-11ea-8f74-08292d3272b3.jpg)

**No content available**

![invalid_detials](https://user-images.githubusercontent.com/23240530/75029411-d8d54e80-5456-11ea-8750-27f19bb06d66.jpg)

  **Questions:**

 none
